### PR TITLE
Workaround for Viomi time drift

### DIFF
--- a/deployment/viomi/etc/init.d/valetudo
+++ b/deployment/viomi/etc/init.d/valetudo
@@ -29,6 +29,14 @@ _fix_timezone() {
 		/sbin/uci commit system
 		/etc/init.d/sysntpd restart
 	fi
+	
+	# workaround stupid viomi time drift
+        echo UTC > /etc/TZ    #set UTC in the timezone file
+        for i in 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16     #{1..16} did not work on my device
+        do
+                ntpd -q -p pool.ntp.org
+                sleep 2
+        done
 }
 
 start_service() {


### PR DESCRIPTION
This change will 
- Add a overwriting of the system timezone to UTC
- Add a for loop at the service start of valetudo to get the NTP time 16 times with delay of 2seconds
This will delay start time by roughly 32 seconds on viomi

## Type of change

Type A:
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] UI Feature
- [ ] Refactor/Code Cleanup
- [ ] Docs
- [ ] Capability implementation for existing core capability
- [ ] New robot implementation

# Description (Type A)

Please include a summary of the change and which issue is fixed (if applicable).
Please also include relevant motivation and context.
This is a workaround for Viomi devices that do have problems with time drifts.
It does add a workaround to the init.d script, setting time to UTC and get time from pool.ntp.org at boot.
